### PR TITLE
fix(skeletonize): correct edge orientation, dataset routing, and soma detection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial changelog file
 - Backward compatibility for `parse_neuroncriteria` import from `crantpy.queries.neurons`
+- Offline unit tests for `crantpy.viz.skeletonize` (`tests/test_skeletonize.py`) covering the SWC dict-to-`TreeNeuron` conversion, soma detection, and `get_skeletons` deduplication (no CAVE credentials required)
+- `dataset` parameter on `skeletonize_neuron` and `skeletonize_neurons_parallel` so the on-demand mesh fetch uses the same dataset as the rest of the call
 
 ### Changed
 
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Backward compatibility maintained with deprecation warning
   - Users should update imports: `from crantpy.utils.decorators import parse_neuroncriteria`
   - Old import location will be removed in a future version
+- `get_skeletons` now deduplicates `root_ids` before fetching and iterates fetches as they complete (`as_completed`), reporting the failing root id on error
+- `skeletonize_neuron` treats `save_to` as an output directory when given multiple root IDs, writing one `<root_id>.swc` per neuron instead of overwriting a single file
 
 ### Deprecated
 
@@ -26,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Import error in tests for `parse_neuroncriteria` function
+- **Skeleton topology**: `_create_node_info_dict` now rebuilds parent pointers from undirected connectivity, fixing inverted roots and dropped branch-point children (meshparty emits `[child, parent]` edges) that produced fragmented skeletons in both the `pcg_skel` and precomputed-fetch paths
+- **Wrong-dataset meshes**: the skeletor fallback in `skeletonize_neuron` now fetches the CloudVolume for the client's dataset instead of always the default dataset
+- **Soma detection**: `detect_soma_skeleton` no longer skips a segment whose only large-radius node is at position 0; `detect_soma_mesh` neighbour counting is now vectorized (was O(n²))
+- `skeletonize_neurons_parallel` colour generation aligns colours to the returned neurons and uses `plt.get_cmap` (compatible with current matplotlib); the precomputed-fetch failure reason in `get_skeletons` is now logged instead of silently swallowed
 
 
 ## Support

--- a/src/crantpy/viz/skeletonize.py
+++ b/src/crantpy/viz/skeletonize.py
@@ -20,8 +20,9 @@ import pcg_skel
 import skeletor as sk
 import trimesh
 import multiprocessing as mp
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
+import time
+import collections
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from numpy.typing import NDArray
 from tqdm import tqdm
@@ -30,7 +31,6 @@ from scipy.spatial import cKDTree
 from caveclient import CAVEclient
 from ..utils.decorators import parse_neuroncriteria, inject_dataset
 from ..utils.cave import get_cave_client as create_client
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
 # Configure matplotlib for proper PDF export
@@ -127,7 +127,7 @@ __all__ = [
 
 
 @parse_neuroncriteria()
-@inject_dataset()  # navis logic import
+@inject_dataset()
 def skeletonize_neuron(
     client: CAVEclient,
     root_id: Union[int, List[int], NDArray],
@@ -138,6 +138,7 @@ def skeletonize_neuron(
     save_to: Optional[str] = None,
     progress: bool = True,
     use_pcg_skel: bool = False,
+    dataset: Optional[str] = None,
     **kwargs: Any,
 ) -> Union[navis.TreeNeuron, navis.NeuronList]:
     """Skeletonize a neuron the main function.
@@ -148,6 +149,10 @@ def skeletonize_neuron(
         CAVE client for data access.
     root_id : int
         Root ID of the neuron to skeletonize.
+    dataset : str, optional
+        Dataset to fetch meshes from in the skeletor fallback. If not given,
+        the ``@inject_dataset`` decorator fills in the default dataset. Should
+        match the dataset ``client`` was built for.
     shave_skeleton : bool, default True
         Remove small protrusions and bristles from skeleton (from my understanding).
     remove_soma_hairball : bool, default False
@@ -181,12 +186,17 @@ def skeletonize_neuron(
     # - Merge disconnected skeletons
     # - Custom node/edge attributes
     """
-    if save_to is not None:
-        save_to = os.path.abspath(save_to)
-        os.makedirs(os.path.dirname(save_to), exist_ok=True)
-
     if navis.utils.is_iterable(root_id):
         root_id_array = np.asarray(root_id).astype(np.int64)
+
+        # For multiple neurons, ``save_to`` is treated as an output directory and
+        # each neuron is written to "<root_id>.swc" so they don't overwrite one
+        # another (the single-neuron branch below treats it as a file path).
+        if save_to is not None:
+            save_dir = os.path.abspath(save_to)
+            os.makedirs(save_dir, exist_ok=True)
+        else:
+            save_dir = None
 
         return navis.NeuronList(
             [
@@ -198,8 +208,11 @@ def skeletonize_neuron(
                     remove_soma_hairball=remove_soma_hairball,
                     assert_id_match=assert_id_match,
                     threads=threads,
-                    save_to=save_to,
+                    save_to=(
+                        os.path.join(save_dir, f"{int(rid)}.swc") if save_dir else None
+                    ),
                     use_pcg_skel=use_pcg_skel,
+                    dataset=dataset,
                     **kwargs,
                 )
                 for rid in tqdm(
@@ -210,6 +223,10 @@ def skeletonize_neuron(
                 )
             ]
         )
+
+    if save_to is not None:
+        save_to = os.path.abspath(save_to)
+        os.makedirs(os.path.dirname(save_to), exist_ok=True)
 
     assert isinstance(
         root_id, (int, np.integer)
@@ -272,7 +289,10 @@ def skeletonize_neuron(
     try:
         from ..utils.cave import get_cloudvolume
 
-        vol = get_cloudvolume()
+        # Use the same dataset the client was built for so the mesh is fetched
+        # from the matching segmentation source (dataset is injected by the
+        # @inject_dataset decorator when not supplied).
+        vol = get_cloudvolume(dataset=dataset)
         mesh_dict = vol.mesh.get(root_id_int) if hasattr(vol, "mesh") else vol.get_mesh(root_id_int)  # type: ignore
 
         if isinstance(mesh_dict, dict) and root_id_int in mesh_dict:
@@ -348,6 +368,7 @@ def skeletonize_neurons_parallel(
     n_cores: Optional[int] = None,
     progress: bool = True,
     color_map: Optional[str] = None,
+    dataset: Optional[str] = None,
     **kwargs: Any,
 ) -> Union[navis.NeuronList, Tuple[navis.NeuronList, List[str]]]:
     """Skeletonize multiple neurons in parallel.
@@ -390,17 +411,13 @@ def skeletonize_neurons_parallel(
 
     sig = inspect.signature(skeletonize_neuron)
     for k in kwargs:
-        if k not in sig.parameters and k not in ("lod", "dataset"):
+        if k not in sig.parameters and k not in ("lod",):
             raise ValueError(f"unexpected keyword argument for skeletonize_neuron: {k}")
 
     kwargs["progress"] = False
     kwargs["threads"] = 1
-
-    try:
-        kwargs["_soma_prefetched"] = False
-    except Exception as e:
-        warnings.warn(f"Failed to pre-fetch soma data: {e}")
-        kwargs["_soma_prefetched"] = False
+    kwargs["dataset"] = dataset
+    kwargs["_soma_prefetched"] = False
 
     funcs = [skeletonize_neuron] * len(root_ids)
     args_list = [[client, root_id] for root_id in root_ids]
@@ -443,8 +460,11 @@ def skeletonize_neurons_parallel(
 
     if color_map is not None:
         try:
-            cmap = cm.get_cmap(color_map, len(root_ids))
-            colors = [mcolors.to_hex(cmap(i)) for i in range(len(root_ids))]
+            # Generate one color per surviving neuron (failures are dropped from
+            # `neurons`) so colors and neurons stay aligned by position.
+            n = len(neurons)
+            cmap = plt.get_cmap(color_map, max(n, 1))
+            colors = [mcolors.to_hex(cmap(i)) for i in range(n)]
             return neurons, colors
         except Exception as e:
             warnings.warn(f"Failed to generate colors: {e}")
@@ -464,18 +484,10 @@ def _assert_id_match(tn: navis.TreeNeuron, root_id: int, client: CAVEclient) -> 
     if root_id == 0:
         raise ValueError("Segmentation ID must not be 0")
 
-    coords = tn.nodes[["x", "y", "z"]].values
-
-    try:
-        warnings.warn(
-            "TODO: assert_id_match is not implemented yet and currently has no effect.",
-            category=UserWarning,
-        )
-        return
-
-    except Exception as e:
-        logger.exception("Unexpected error during ID match assertion for %s", root_id)
-        raise
+    warnings.warn(
+        "assert_id_match is not implemented yet and currently has no effect.",
+        category=UserWarning,
+    )
 
 
 def _worker_wrapper(
@@ -511,6 +523,10 @@ def _worker_wrapper(
         raise
     except (requests.HTTPError, requests.ConnectionError, requests.Timeout) as e:
         try:
+            # Brief backoff before the single retry: these errors are usually
+            # transient (rate limiting / overloaded server), so an immediate
+            # retry tends to just fail the same way.
+            time.sleep(2)
             result = f(*args, **kwargs)
             if result is None:
                 return {
@@ -520,7 +536,9 @@ def _worker_wrapper(
                     "message": "Function returned None after retry",
                 }
             return result
-        except BaseException as retry_error:
+        except KeyboardInterrupt:
+            raise
+        except Exception as retry_error:
             logger.warning(
                 "Network error for neuron %s: %s, retry failed: %s",
                 root_id,
@@ -556,14 +574,26 @@ def _worker_wrapper(
 def _create_node_info_dict(
     vertices: NDArray, edges: NDArray
 ) -> Dict[int, Dict[str, Any]]:
-    """Create node info dictionary for SWC format."""
-    node_info = {}
-    parent_map = {}
+    """Create node info dictionary for SWC format.
+
+    Edge orientation from the various skeleton sources is not guaranteed to be
+    ``[parent, child]`` -- meshparty (the pcg_skel path) emits ``[child, parent]``
+    and precomputed CAVE skeleton edges may be unordered. Parent pointers are
+    therefore derived from a breadth-first traversal of the *undirected*
+    connectivity rather than trusting the edge direction. This guarantees
+    exactly one parent per node and one root per connected component, and avoids
+    silently inverting roots or dropping the children of branch points.
+
+    Absent any soma information the root of each component is the lowest vertex
+    index (deterministic but arbitrary); callers that need a somatic root should
+    reroot afterwards (see ``_apply_soma_processing``).
+    """
+    node_info: Dict[int, Dict[str, Any]] = {}
 
     for i, coord in enumerate(vertices):
         node_info[i] = {
             "PointNo": i + 1,
-            "Type": 0,
+            "Type": 3,
             "X": float(coord[0]),
             "Y": float(coord[1]),
             "Z": float(coord[2]),
@@ -571,31 +601,44 @@ def _create_node_info_dict(
             "Parent": -1,
         }
 
-    child_nodes = set()
-    parent_nodes_in_edges = set()
+    # Build undirected adjacency from the edge list.
+    adjacency: Dict[int, set] = collections.defaultdict(set)
     for edge in edges:
-        parent, child = edge
-        parent_map[child] = parent
-        child_nodes.add(child)
-        parent_nodes_in_edges.add(parent)
+        a, b = int(edge[0]), int(edge[1])
+        adjacency[a].add(b)
+        adjacency[b].add(a)
 
-        if node_info[parent]["Type"] == 0:
-            node_info[parent]["Type"] = 3
-        if node_info[child]["Type"] == 0:
-            node_info[child]["Type"] = 3
+    # Derive a rooted forest via BFS: every node gets a single parent and each
+    # connected component gets exactly one root (lowest index, deterministic).
+    parent_map: Dict[int, int] = {}
+    seen: set = set()
+    for start in node_info:
+        if start in seen:
+            continue
+        seen.add(start)
+        queue = collections.deque([start])
+        while queue:
+            cur = queue.popleft()
+            for neighbor in sorted(adjacency[cur]):
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    parent_map[neighbor] = cur
+                    queue.append(neighbor)
 
     for child, parent in parent_map.items():
-        node_info[child]["Parent"] = parent + 1
+        node_info[child]["Parent"] = parent + 1  # SWC node ids are 1-indexed
 
-    all_nodes = set(node_info.keys())
-    root_nodes = all_nodes - child_nodes
-    for root in root_nodes:
-        node_info[root]["Type"] = 1
-        node_info[root]["Parent"] = -1
-
+    # Classify node types from undirected degree: roots (1), leaves/endpoints (6),
+    # everything else intermediate/branch (3).
+    root_nodes = set(node_info.keys()) - set(parent_map.keys())
     for node_idx, info in node_info.items():
-        if node_idx in child_nodes and node_idx not in parent_nodes_in_edges:
-            node_info[node_idx]["Type"] = 6
+        if node_idx in root_nodes:
+            info["Type"] = 1
+            info["Parent"] = -1
+        elif len(adjacency[node_idx]) <= 1:
+            info["Type"] = 6
+        else:
+            info["Type"] = 3
 
     return node_info
 
@@ -664,7 +707,10 @@ def detect_soma_skeleton(
         rad = np.array([radii[node_id] for node_id in seg])
         is_big = np.where(rad > min_rad)[0]
 
-        if not any(is_big):
+        # `is_big` holds the positions of large-radius nodes; an empty array
+        # means none qualify. (Using ``any(is_big)`` here would wrongly skip a
+        # segment whose only large node sits at position 0.)
+        if is_big.size == 0:
             continue
 
         for stretch in np.split(is_big, np.where(np.diff(is_big) != 1)[0] + 1):
@@ -713,23 +759,17 @@ def detect_soma_mesh(mesh: trimesh.Trimesh) -> NDArray:
         )
         return np.array([])
 
-    from scipy.spatial import cKDTree
-
     try:
         tree = cKDTree(mesh.vertices)
     except Exception as e:
         warnings.warn(f"Failed to build KDTree for soma detection: {e}")
         return np.array([])
 
-    # cKDTree.query_ball_point returns lists of indices; compute lengths explicitly
-    n = mesh.vertices.shape[0]
-    n_neighbors = np.zeros(n, dtype=int)
-    for i, v in enumerate(mesh.vertices):
-        dist, _ix = tree.query(v, k=n, distance_upper_bound=4000)
-        if np.isscalar(dist):
-            n_neighbors[i] = int(np.isfinite(dist))
-        else:
-            n_neighbors[i] = int(np.isfinite(dist).sum())
+    # Count neighbours within 4 µm of each vertex in a single vectorized call;
+    # dense clusters mark the soma. A per-vertex ``tree.query(v, k=n)`` here
+    # would be O(n^2) and pathological on real meshes (tens of thousands of
+    # vertices).
+    n_neighbors = tree.query_ball_point(mesh.vertices, r=4000, return_length=True)
 
     seed = np.argmax(n_neighbors)
 
@@ -784,8 +824,9 @@ def get_skeletons(
 ) -> navis.NeuronList:
     """Fetch skeletons for multiple neurons.
 
-    Tries to get precomputed skeletons first, then falls back to
-    on-demand skeletonization if needed. if id more than one root_id, it will use the parallel skeletonization function.
+    Tries to get precomputed skeletons first, then falls back to on-demand
+    skeletonization if needed. Multiple root IDs are fetched concurrently using
+    a thread pool (see ``max_threads``).
 
     Parameters
     ----------
@@ -823,14 +864,13 @@ def get_skeletons(
     else:
         root_ids_list = [int(x) for x in root_ids]
 
-    root_ids = np.asarray(root_ids_list, dtype=np.int64)
-
-    root_ids = np.asarray(root_ids, dtype=np.int64)
+    # Drop duplicates (preserving first-seen order) so we don't fetch the same
+    # neuron twice and so the final id-based reindexing stays unambiguous.
+    root_ids = pd.unique(np.asarray(root_ids_list, dtype=np.int64))
 
     client = create_client(dataset=dataset)
 
     skeletons = []
-    failed_ids = []
 
     def fetch_single_skeleton(root_id: int) -> Optional[navis.TreeNeuron]:
         """Fetch single skeleton with fallback strategies."""
@@ -846,10 +886,18 @@ def get_skeletons(
 
                     tn = navis.TreeNeuron(df, id=root_id, units="1 nm")
                     return tn
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(
+                    "Precomputed skeleton fetch/parse failed for %s (%s: %s); "
+                    "falling back to on-demand skeletonization",
+                    root_id,
+                    type(e).__name__,
+                    e,
+                )
 
-            tn = skeletonize_neuron(client, root_id, progress=False, **kwargs)
+            tn = skeletonize_neuron(
+                client, root_id, progress=False, dataset=dataset, **kwargs
+            )
             return tn
 
         except Exception as e:
@@ -859,8 +907,6 @@ def get_skeletons(
                 return None
             else:
                 try:
-                    import pandas as pd
-
                     df = pd.DataFrame(
                         {
                             "node_id": [1],
@@ -876,19 +922,20 @@ def get_skeletons(
                     return None
 
     if max_threads > 1 and len(root_ids) > 1:
-        from concurrent.futures import ThreadPoolExecutor
-
         with ThreadPoolExecutor(max_workers=max_threads) as executor:
-            futures = [executor.submit(fetch_single_skeleton, rid) for rid in root_ids]
+            future_to_rid = {
+                executor.submit(fetch_single_skeleton, rid): rid for rid in root_ids
+            }
 
             results = []
             for future in tqdm(
-                futures,
+                as_completed(future_to_rid),
                 desc="Fetching skeletons",
                 total=len(root_ids),
                 disable=not progress or len(root_ids) == 1,
                 leave=False,
             ):
+                rid = future_to_rid[future]
                 try:
                     result = future.result()
                     if result is not None:
@@ -896,7 +943,7 @@ def get_skeletons(
                 except Exception as e:
                     if omit_failures is None:
                         raise
-                    warnings.warn(f"Failed to fetch skeleton: {e}")
+                    warnings.warn(f"Failed to fetch skeleton for {rid}: {e}")
 
             skeletons = results
     else:
@@ -1079,8 +1126,10 @@ def _shave_skeleton(tn: navis.TreeNeuron) -> None:
     parent_is_bp = tn.nodes.parent_id.isin(bp)
     twigs = tn.nodes.loc[is_end & parent_is_bp, "node_id"].values
 
-    tn._nodes = tn.nodes.loc[~tn.nodes.node_id.isin(twigs)].copy()
-    tn._clear_temp_attr()
+    # Drop the short terminal twigs via the public navis API rather than poking
+    # at tn._nodes / tn._clear_temp_attr() directly.
+    if len(twigs):
+        navis.subset_neuron(tn, ~tn.nodes.node_id.isin(twigs), inplace=True)
 
 
 def _apply_soma_processing(

--- a/tests/test_skeletonize.py
+++ b/tests/test_skeletonize.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Offline unit tests for crantpy.viz.skeletonize.
+
+These cover the pure, network-free helpers -- in particular the
+dict-to-TreeNeuron conversion (``_create_node_info_dict`` /
+``_swc_dict_to_dataframe``), radius-based soma detection, and the
+dataset/signature plumbing. They do not require CAVE credentials or any
+remote access.
+"""
+
+import inspect
+
+import numpy as np
+import pandas as pd
+import navis
+import pytest
+
+from crantpy.viz import skeletonize as S
+
+
+# ---------------------------------------------------------------------------
+# _create_node_info_dict / _swc_dict_to_dataframe
+# ---------------------------------------------------------------------------
+def _roots(node_info):
+    return sorted(k for k, v in node_info.items() if v["Parent"] == -1)
+
+
+def _parent_count(node_info):
+    """Number of nodes that have a parent (Parent != -1)."""
+    return sum(1 for v in node_info.values() if v["Parent"] != -1)
+
+
+def _as_treeneuron(node_info):
+    df = S._swc_dict_to_dataframe(node_info)
+    return navis.TreeNeuron(df, units="1 nm", id=1)
+
+
+def test_node_info_linear_chain_meshparty_orientation():
+    """meshparty emits edges as [child, parent]; the root must be vertex 0."""
+    verts = np.array([[i, 0, 0] for i in range(4)], dtype=float)
+    # child -> parent edges for chain 0-1-2-3 rooted at 0
+    edges = np.array([[1, 0], [2, 1], [3, 2]])
+    ni = S._create_node_info_dict(verts, edges)
+
+    assert _roots(ni) == [0]  # vertex 0 is the single root
+    # exactly one parent per non-root node
+    assert _parent_count(ni) == 3
+    # Parent links are 1-indexed (PointNo); node i's parent is i-1
+    assert ni[1]["Parent"] == 1
+    assert ni[2]["Parent"] == 2
+    assert ni[3]["Parent"] == 3
+
+
+def test_node_info_branch_node_keeps_all_children():
+    """Regression: branch points must not lose children to parent overwrites."""
+    # Y shape: 0-1, 1-2, 1-3, 3-4  (vertex 1 is a branch with children 2 and 3)
+    verts = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0], [1, 2, 0]], float)
+    edges = np.array([[1, 0], [2, 1], [3, 1], [4, 3]])  # [child, parent]
+    ni = S._create_node_info_dict(verts, edges)
+
+    assert _roots(ni) == [0]
+    # children of the branch node (vertex 1 == PointNo 2) are vertices 2 and 3
+    children_of_branch = sorted(k for k, v in ni.items() if v["Parent"] == 2)
+    assert children_of_branch == [2, 3]
+    # resulting neuron is a single connected tree with one root
+    tn = _as_treeneuron(ni)
+    assert tn.n_nodes == 5
+    assert len(np.atleast_1d(tn.root)) == 1
+
+
+def test_node_info_orientation_invariant():
+    """Reversing edge orientation must yield the same rooted tree."""
+    verts = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0], [1, 2, 0]], float)
+    edges_cp = np.array([[1, 0], [2, 1], [3, 1], [4, 3]])  # [child, parent]
+    edges_pc = edges_cp[:, ::-1]  # [parent, child]
+
+    ni_cp = S._create_node_info_dict(verts, edges_cp)
+    ni_pc = S._create_node_info_dict(verts, edges_pc)
+
+    parents_cp = {k: v["Parent"] for k, v in ni_cp.items()}
+    parents_pc = {k: v["Parent"] for k, v in ni_pc.items()}
+    assert parents_cp == parents_pc
+    assert _roots(ni_cp) == [0]
+
+
+def test_node_info_duplicate_edges_are_safe():
+    """Duplicate / undirected edges must not create extra parents or cycles."""
+    verts = np.array([[i, 0, 0] for i in range(3)], dtype=float)
+    edges = np.array([[1, 0], [0, 1], [2, 1], [2, 1]])  # duplicates + reversed
+    ni = S._create_node_info_dict(verts, edges)
+    assert _roots(ni) == [0]
+    assert _parent_count(ni) == 2  # one parent each for nodes 1 and 2
+
+
+def test_node_info_disconnected_components_get_one_root_each():
+    """Each connected component must get exactly one root."""
+    verts = np.array([[i, 0, 0] for i in range(5)], dtype=float)
+    # component A: 0-1-2 ; component B: 3-4
+    edges = np.array([[1, 0], [2, 1], [4, 3]])
+    ni = S._create_node_info_dict(verts, edges)
+    assert _roots(ni) == [0, 3]
+    assert _parent_count(ni) == 3  # 5 nodes, 2 components -> 3 parented nodes
+
+
+def test_node_info_isolated_vertex_is_its_own_root():
+    verts = np.array([[0, 0, 0], [1, 0, 0], [5, 5, 5]], dtype=float)
+    edges = np.array([[1, 0]])  # vertex 2 has no edges
+    ni = S._create_node_info_dict(verts, edges)
+    assert 2 in _roots(ni)
+    assert ni[2]["Type"] == 1  # isolated node classified as root
+
+
+def test_node_info_type_classification():
+    """Root -> 1, leaf/endpoint -> 6, intermediate/branch -> 3."""
+    verts = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]], float)
+    edges = np.array([[1, 0], [2, 1], [3, 1]])  # root 0, branch 1, leaves 2 & 3
+    ni = S._create_node_info_dict(verts, edges)
+    assert ni[0]["Type"] == 1  # root
+    assert ni[1]["Type"] == 3  # branch (degree 3)
+    assert ni[2]["Type"] == 6  # leaf
+    assert ni[3]["Type"] == 6  # leaf
+
+
+def test_node_info_mixed_orientation_within_tree():
+    """Edges with inconsistent orientation within one tree still yield one root."""
+    verts = np.array([[i, 0, 0] for i in range(4)], dtype=float)
+    # chain 0-1-2-3 given as [parent,child], [child,parent], [parent,child]
+    edges = np.array([[0, 1], [2, 1], [2, 3]])
+    ni = S._create_node_info_dict(verts, edges)
+    assert _roots(ni) == [0]
+    assert _parent_count(ni) == 3
+    tn = _as_treeneuron(ni)
+    assert tn.n_nodes == 4
+    assert len(np.atleast_1d(tn.root)) == 1
+
+
+def test_swc_dict_to_dataframe_schema():
+    verts = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+    edges = np.array([[1, 0], [2, 1]])
+    df = S._swc_dict_to_dataframe(S._create_node_info_dict(verts, edges))
+    assert list(df.columns) == ["PointNo", "Type", "X", "Y", "Z", "Radius", "Parent"]
+    assert df["PointNo"].tolist() == [1, 2, 3]  # sorted by PointNo
+    for col in ["X", "Y", "Z", "Radius"]:
+        assert df[col].dtype == float
+
+
+# ---------------------------------------------------------------------------
+# detect_soma_skeleton
+# ---------------------------------------------------------------------------
+def _linear_neuron(radii):
+    n = len(radii)
+    df = pd.DataFrame(
+        {
+            "node_id": list(range(1, n + 1)),
+            "parent_id": [-1] + list(range(1, n)),
+            "x": np.arange(n, dtype=float),
+            "y": np.zeros(n),
+            "z": np.zeros(n),
+            "radius": np.asarray(radii, dtype=float),
+        }
+    )
+    return navis.TreeNeuron(df, units="1 nm", id=1)
+
+
+def test_detect_soma_skeleton_no_radius_returns_none():
+    tn = _linear_neuron([100.0] * 5)
+    tn.nodes.drop(columns=["radius"], inplace=True)
+    assert S.detect_soma_skeleton(tn) is None
+
+
+def test_detect_soma_skeleton_no_large_nodes_returns_none():
+    tn = _linear_neuron([100.0] * 6)  # all below default min_rad=800
+    assert S.detect_soma_skeleton(tn) is None
+
+
+def test_detect_soma_skeleton_finds_large_radius_blob():
+    # three consecutive large-radius nodes -> soma candidate; the largest wins
+    radii = [100, 100, 900, 1500, 1000, 100, 100]
+    tn = _linear_neuron(radii)
+    soma = S.detect_soma_skeleton(tn, min_rad=800, N=3)
+    assert soma is not None
+    # the detected node must be the largest-radius one (node_id 4, radius 1500)
+    assert tn.nodes.set_index("node_id").loc[soma, "radius"] == 1500
+
+
+def test_detect_soma_skeleton_large_node_at_segment_start():
+    """Regression for the ``any(is_big)`` bug.
+
+    navis orders each segment leaf-first, so a lone large node at a leaf lands
+    at position 0 of its segment. The old ``not any(is_big)`` test treated that
+    index value 0 as falsy and silently skipped the segment; the corrected
+    ``is_big.size == 0`` check detects it.
+    """
+    radii = [100.0, 100.0, 100.0, 2000.0]  # the leaf (node_id 4) is the big one
+    tn = _linear_neuron(radii)
+    soma = S.detect_soma_skeleton(tn, min_rad=800, N=1)
+    assert soma is not None
+    assert tn.nodes.set_index("node_id").loc[soma, "radius"] == 2000.0
+
+
+# ---------------------------------------------------------------------------
+# detect_soma_mesh
+# ---------------------------------------------------------------------------
+def test_detect_soma_mesh_none_returns_empty():
+    assert S.detect_soma_mesh(None).size == 0
+
+
+def test_detect_soma_mesh_too_few_vertices_returns_empty():
+    import trimesh
+
+    m = trimesh.creation.box(extents=(1, 1, 1))  # 8 vertices < 100
+    out = S.detect_soma_mesh(m)
+    assert isinstance(out, np.ndarray)
+    assert out.size == 0
+
+
+def test_detect_soma_mesh_neighbor_count_matches_reference():
+    """Lock the vectorized neighbor count against the old per-vertex loop.
+
+    The patch replaced an O(n^2) ``tree.query(v, k=n, distance_upper_bound=4000)``
+    loop with ``tree.query_ball_point(..., r=4000, return_length=True)``; both
+    count vertices within 4 µm (including the vertex itself), so the per-vertex
+    counts must be identical.
+    """
+    import trimesh
+    from scipy.spatial import cKDTree
+
+    m = trimesh.creation.icosphere(subdivisions=2, radius=3000.0)
+    tree = cKDTree(m.vertices)
+    n = len(m.vertices)
+    reference = np.array(
+        [
+            int(np.isfinite(tree.query(v, k=n, distance_upper_bound=4000)[0]).sum())
+            for v in m.vertices
+        ]
+    )
+    vectorized = np.asarray(
+        tree.query_ball_point(m.vertices, r=4000, return_length=True)
+    )
+    assert np.array_equal(vectorized, reference)
+
+
+# ---------------------------------------------------------------------------
+# get_skeletons -- dedup + ordering contract (offline, mocked)
+# ---------------------------------------------------------------------------
+def test_get_skeletons_dedups_and_preserves_order(monkeypatch):
+    """Duplicate root_ids are collapsed; output is reindexed to unique order."""
+
+    class _DummySkeletonSvc:
+        def get_skeleton(self, root_id, output_format="dict"):
+            return None  # force the skeletonize_neuron fallback
+
+    class _DummyClient:
+        skeleton = _DummySkeletonSvc()
+
+    calls = []
+
+    def _fake_skeletonize(client, root_id, progress=False, dataset=None, **kw):
+        calls.append(int(root_id))
+        tn = _linear_neuron([1.0, 1.0])
+        tn.id = int(root_id)
+        return tn
+
+    monkeypatch.setattr(S, "create_client", lambda dataset=None: _DummyClient())
+    monkeypatch.setattr(S, "skeletonize_neuron", _fake_skeletonize)
+
+    nl = S.get_skeletons([123, 123, 456], progress=False, max_threads=1)
+
+    assert len(nl) == 2
+    assert list(nl.id) == [123, 456]
+    assert sorted(calls) == [123, 456]  # each unique id fetched exactly once
+
+
+# ---------------------------------------------------------------------------
+# dataset / signature plumbing
+# ---------------------------------------------------------------------------
+def test_skeletonize_neuron_has_dataset_param():
+    params = inspect.signature(S.skeletonize_neuron).parameters
+    assert "dataset" in params
+
+
+def test_skeletonize_neurons_parallel_has_dataset_param():
+    params = inspect.signature(S.skeletonize_neurons_parallel).parameters
+    assert "dataset" in params
+
+
+def test_assert_id_match_warns_and_is_noop():
+    tn = _linear_neuron([100.0, 100.0, 100.0])
+    with pytest.warns(UserWarning):
+        S._assert_id_match(tn, root_id=123, client=None)
+
+
+def test_assert_id_match_rejects_zero_id():
+    tn = _linear_neuron([100.0, 100.0, 100.0])
+    with pytest.raises(ValueError):
+        S._assert_id_match(tn, root_id=0, client=None)


### PR DESCRIPTION
## Description

Hardening pass on `crantpy.viz.skeletonize` (the `get_skeletons` / `skeletonize_neuron` path). Fixes a skeleton-topology bug, a wrong-dataset bug, and a soma-detection bug, removes an O(n²) hotspot, and adds offline tests. Public API is unchanged.

### Highlights

- **Edge orientation (topology bug).** `_create_node_info_dict` trusted edge direction (`parent, child = edge`), but meshparty emits `[child, parent]` and precomputed CAVE edges may be unordered → inverted roots and branch points silently losing children, producing **fragmented neurons**. It now rebuilds parent pointers via a BFS over undirected adjacency: exactly one parent per node and one root per connected component. Affects both the `pcg_skel` and precomputed-fetch paths.
- **Wrong-dataset meshes.** The skeletor fallback called `get_cloudvolume()` with no dataset, so meshes always came from the default segmentation regardless of the client's dataset. Added a real `dataset` parameter (so the existing `@inject_dataset` decorator actually works) and threaded it end-to-end (`get_skeletons` → `skeletonize_neuron` → `get_cloudvolume(dataset=...)`).
- **Soma detection.** `detect_soma_skeleton` skipped a segment whose only large-radius node sat at index 0 (`not any(is_big)` tested index *values*, not emptiness). `detect_soma_mesh` replaced an O(n²) per-vertex `tree.query(k=n)` loop with a single vectorized `query_ball_point(..., return_length=True)`.
- **Robustness / cleanup.** Multi-ID `save_to` now writes one `<root_id>.swc` per neuron instead of overwriting a single file; `get_skeletons` deduplicates `root_ids`, logs the previously silently-swallowed precomputed-fetch error, and iterates with `as_completed` (per-id failure messages); `color_map` uses `plt.get_cmap` (the old `cm.get_cmap` is removed in modern matplotlib) and sizes colours to the surviving neurons; `_shave_skeleton` uses `navis.subset_neuron` instead of mutating `tn._nodes`; dead code removed.

### Type of change

- [x] Bug fix (correctness)
- [x] Tests
- [x] Breaking change — none. `dataset` is an additive optional parameter; `__all__` is unchanged.

### Testing

- New `tests/test_skeletonize.py`: 21 offline unit tests (no CAVE credentials) covering the dict→`TreeNeuron` conversion (orientation invariance, branch-child retention, disconnected components, type classification), the soma-detection regressions, the `detect_soma_mesh` neighbour-count equivalence, and the `get_skeletons` dedup/ordering contract. All pass.
- `black` clean; `ruff` errors on this file reduced from 13 → 6 (all remaining are pre-existing in untouched code; this change introduces none).
- Not run locally: the credentialed test suite (needs CAVE/Seatable auth) and `build_docs.sh` (Poetry not installed locally). The docs CI builds on PR with `execute_notebooks: 'off'`, and only `docs/changelog.md` changed (API docs are autodoc).

### Checklist

- [x] Type hints on new/changed functions
- [x] No public API change → lazy `__init__` files unchanged (`mkinit` is a no-op; `__all__` identical)
- [x] Changelog updated (`docs/changelog.md`, `[Unreleased]`)
- [x] Code formatted with Black
- [x] Conventional commit message

### Related issues

_None._
